### PR TITLE
Always force protodep up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
           CI_SONATYPE_RELEASE: version
         run: |
           .github/decodekey.sh
-          sbt -J-Xms2048M -J-Xmx2048M -J-Xss6M -J-XX:ReservedCodeCacheSize=256M -J-Dfile.encoding=UTF-8 bintrayWhoami ci-release
+          sbt -J-Xms2048M -J-Xmx2048M -J-Xss6M -J-XX:ReservedCodeCacheSize=256M -J-Dfile.encoding=UTF-8 ci-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,4 +32,4 @@ jobs:
           CI_SONATYPE_RELEASE: version
         run: |
           .github/decodekey.sh
-          sbt -J-Xms2048M -J-Xmx2048M -J-Xss6M -J-XX:ReservedCodeCacheSize=256M -J-Dfile.encoding=UTF-8 ci-release
+          sbt -J-Xms2048M -J-Xmx2048M -J-Xss6M -J-XX:ReservedCodeCacheSize=256M -J-Dfile.encoding=UTF-8 bintrayWhoami ci-release

--- a/src/main/scala/com/coralogix/sbtprotodep/GrpcDependencies.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/GrpcDependencies.scala
@@ -13,7 +13,7 @@ import scala.sys.process.Process
 object GrpcDependencies extends AutoPlugin {
   object autoImport {
     val protodepRoot = settingKey[File]("Directory where the protodep.toml file is")
-    val protodepUp = taskKey[Unit]("Runs 'protodep up'")
+    val protodepUp = taskKey[Unit]("Runs 'protodep up -f' but only if protodep.toml has changed")
     val forcedProtodepUp = taskKey[Unit]("Runs 'protodep up -f'")
   }
 
@@ -49,7 +49,7 @@ object GrpcDependencies extends AutoPlugin {
     val protodepBinary = Protodep.autoImport.protodepBinary.value
 
     def run(): Unit =
-      protodepBinary.up(root, forced = false)
+      protodepBinary.up(root, forced = true)
 
     val cachedProtodepUp = Tracked.inputChanged[HashModifiedFileInfo, Unit](
       s.cacheStoreFactory.make("protodep.toml")


### PR DESCRIPTION
With this change, the difference between the `protodepUp` and `forcedProtodepUp` tasks is only caching. The underlying `protodep` tool is always called with the force flag set.