### PR TITLE
Make protodepUp a dependency of PB.generate

### DIFF
--- a/src/main/scala/com/coralogix/sbtprotodep/GrpcDependencies.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/GrpcDependencies.scala
@@ -34,10 +34,10 @@ object GrpcDependencies extends AutoPlugin {
       scalapb.gen(grpc = true)          -> (sourceManaged in Compile).value,
       scalapb.zio_grpc.ZioCodeGenerator -> (sourceManaged in Compile).value
     ),
-    (compile in Compile) := ((compile in Compile) dependsOn protodepUp).value,
-    protodepRoot         := (ThisBuild / baseDirectory).value,
-    protodepUp           := protodepUpTask.value,
-    forcedProtodepUp     := forcedProtodepUpTask.value
+    (PB.generate in Compile) := ((PB.generate in Compile) dependsOn protodepUp).value,
+    protodepRoot             := (ThisBuild / baseDirectory).value,
+    protodepUp               := protodepUpTask.value,
+    forcedProtodepUp         := forcedProtodepUpTask.value
   )
 
   private lazy val protodepUpTask = Def.task {


### PR DESCRIPTION
This change will ensure protoDepUp runs when running `protocGenerate` to generate sources, and without compiling.