### PR TITLE
Allow different project name from path

### DIFF
--- a/src/main/scala/com/coralogix/sbtprotodep/Protodep.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/Protodep.scala
@@ -14,8 +14,8 @@ object Protodep extends AutoPlugin {
 
   import autoImport._
 
-  def generateProject(name: String) =
-    Project(name, file(name))
+  def generateProject(path: String, name: Option[String] = None) =
+    Project(name.getOrElse(path), file(path))
       .enablePlugins(GrpcDependencies)
       .settings(
         protodepVersion := "0.1.2-1-ge811cd8",

--- a/src/main/scala/com/coralogix/sbtprotodep/Protodep.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/Protodep.scala
@@ -14,8 +14,8 @@ object Protodep extends AutoPlugin {
 
   import autoImport._
 
-  def generateProject(path: String, name: Option[String] = None) =
-    Project(name.getOrElse(path), file(path))
+  def generateProject(name: String, path: Option[String] = None) =
+    Project(name, file(path.getOrElse(name)))
       .enablePlugins(GrpcDependencies)
       .settings(
         protodepVersion := "0.1.2-1-ge811cd8",


### PR DESCRIPTION
This allows e.g. to generate in the root project. The project name will not accept `.`.