### PR TITLE
Update protofetch and use fetch --locked on CI

### DIFF
--- a/src/main/scala/com/coralogix/sbtprotodep/GrpcDependencies.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/GrpcDependencies.scala
@@ -66,7 +66,7 @@ object GrpcDependencies extends AutoPlugin {
     val https = protodepUseHttps.value
 
     def run(): Unit =
-      protodepBinary.fetchProtoFiles(root, locked = ci, https = https)
+      protodepBinary.fetchProtoFiles(root, ci = ci, https = https)
 
     val cachedProtodepUp = Tracked.inputChanged[HashModifiedFileInfo, Unit](
       s.cacheStoreFactory.make("protodep.toml")

--- a/src/main/scala/com/coralogix/sbtprotodep/backends/BackendBinary.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/backends/BackendBinary.scala
@@ -15,7 +15,7 @@ import scala.language.postfixOps
 
 trait BackendBinary {
   def isVersion(desiredVersion: String): Boolean
-  def fetchProtoFiles(root: File, locked: Boolean, https: Boolean): Unit
+  def fetchProtoFiles(root: File, ci: Boolean, https: Boolean): Unit
   def updateProtoFiles(root: File, https: Boolean): Unit
   val binary: File
   private[backends] def version(): Option[String]

--- a/src/main/scala/com/coralogix/sbtprotodep/backends/BackendBinary.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/backends/BackendBinary.scala
@@ -15,7 +15,8 @@ import scala.language.postfixOps
 
 trait BackendBinary {
   def isVersion(desiredVersion: String): Boolean
-  def fetchProtoFiles(root: File, forced: Boolean, cleanup: Boolean, https: Boolean): Unit
+  def fetchProtoFiles(root: File, locked: Boolean, https: Boolean): Unit
+  def updateProtoFiles(root: File, https: Boolean): Unit
   val binary: File
   private[backends] def version(): Option[String]
 }
@@ -169,10 +170,10 @@ object BackendBinary {
     System.getProperty("os.name").toLowerCase match {
       case mac if mac.contains("mac") =>
         System.getProperty("os.arch").toLowerCase match {
-          case arm if arm.contains("aarch64") => "darwin_arm64"
-          case _                              => "darwin_amd64"
+          case arm if arm.contains("aarch64") => "aarch64-apple-darwin"
+          case _                              => "x86_64-apple-darwin"
         }
-      case win if win.contains("win") => "windows_amd64"
+      case win if win.contains("win") => "x86_64-pc-windows-msvc"
       case linux if linux.contains("linux") =>
         System.getProperty("os.arch").toLowerCase match {
           case "aarch64"          => "aarch64-unknown-linux-musl"

--- a/src/main/scala/com/coralogix/sbtprotodep/backends/ProtodepBinary.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/backends/ProtodepBinary.scala
@@ -26,7 +26,7 @@ class ProtodepBinary(
     }
   }
 
-  def fetchProtoFiles(root: File, locked: Boolean, https: Boolean): Unit = {
+  def fetchProtoFiles(root: File, ci: Boolean, https: Boolean): Unit = {
     val args =
       List(
         Some("--cleanup"),

--- a/src/main/scala/com/coralogix/sbtprotodep/backends/ProtodepBinary.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/backends/ProtodepBinary.scala
@@ -26,12 +26,21 @@ class ProtodepBinary(
     }
   }
 
-  def fetchProtoFiles(root: File, forced: Boolean, cleanup: Boolean, https: Boolean): Unit = {
+  def fetchProtoFiles(root: File, locked: Boolean, https: Boolean): Unit = {
     val args =
       List(
-        if (forced) Some("-f") else None,
-        if (cleanup) Some("-c") else None,
-        if (https) Some("-u") else None
+        Some("--cleanup"),
+        if (https) Some("--use-https") else None
+      ).flatten
+    Process(binary.toString :: "up" :: args, root) ! log
+  }
+
+  def updateProtoFiles(root: File, https: Boolean): Unit = {
+    val args =
+      List(
+        Some("-f"),
+        Some("--cleanup"),
+        if (https) Some("--use-https") else None
       ).flatten
     Process(binary.toString :: "up" :: args, root) ! log
   }

--- a/src/main/scala/com/coralogix/sbtprotodep/backends/ProtofetchBinary.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/backends/ProtofetchBinary.scala
@@ -23,8 +23,8 @@ class ProtofetchBinary(
     }
   }
 
-  def fetchProtoFiles(root: File, locked: Boolean, https: Boolean): Unit = {
-    val args = if (locked) List("--locked") else Nil
+  def fetchProtoFiles(root: File, ci: Boolean, https: Boolean): Unit = {
+    val args = if (ci) List("--locked") else Nil
     log.debug(s"Using binary: ${binary.toString}")
     Process(binary.toString :: "fetch" :: args, root) ! log
   }

--- a/src/main/scala/com/coralogix/sbtprotodep/backends/ProtofetchBinary.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/backends/ProtofetchBinary.scala
@@ -23,17 +23,16 @@ class ProtofetchBinary(
     }
   }
 
-  //TODO: Protofetch does not support some of these flags. As protofetch evolves, if none of these make sense consider changing the base trait
-  def fetchProtoFiles(root: File, forced: Boolean, cleanup: Boolean, https: Boolean): Unit = {
-    println("Ignoring any force, cleanup, https flags as protofetch does not support them")
-    val args: List[String] =
-      List(
-        if (forced) Some("-f") else None,
-        //        if (cleanup) Some("-c") else None,
-        //        if (https) Some("-u") else None
-        None
-      ).flatten
-    println(s"Using binary:  ${binary.toString}")
+  def fetchProtoFiles(root: File, locked: Boolean, https: Boolean): Unit = {
+    val args = if (locked) List("--locked") else Nil
+    log.debug(s"Using binary: ${binary.toString}")
     Process(binary.toString :: "fetch" :: args, root) ! log
   }
+
+  def updateProtoFiles(root: File, https: Boolean): Unit = {
+    log.debug(s"Using binary: ${binary.toString}")
+    Process(binary.toString :: "update" :: Nil, root) ! log
+    Process(binary.toString :: "fetch" :: Nil, root) ! log
+  }
+
 }

--- a/src/main/scala/com/coralogix/sbtprotodep/package.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/package.scala
@@ -1,6 +1,6 @@
 package com.coralogix
 
 package object sbtprotodep {
-  lazy val protofetchVersion = "v0.0.25"
+  lazy val protofetchVersion = "v0.1.0"
   lazy val protodepVersion = "v0.1.6"
 }


### PR DESCRIPTION
This PR updates `protofetch` to `0.1.0`.

The main change is that when running on CI (detected using the `insideCI` sbt setting), we will use `protofetch fetch --locked`, and when running locally it will be just `protofetch fetch`. This makes it pick up `protofetch.toml` changes automatically when developing, while on CI protofetch will make sure the dependencies are exactly as stated in the lock file.
