### PR TITLE
project maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
+        uses: olafurpg/setup-scala@v14
         with:
-          java-version: "adopt@1.11"
+          java-version: "temurin@17"
       - name: Coursier cache
         uses: coursier/cache-action@v5
       - name: Build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v14
         with:
-          java-version: "temurin@17"
+          java-version: "openjdk@1.17"
       - name: Coursier cache
         uses: coursier/cache-action@v5
       - name: Build and test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Build and test
         run: |
           sbt -v -J-Xms2048M -J-Xmx2048M -J-Xss6M -J-XX:ReservedCodeCacheSize=256M -J-Dfile.encoding=UTF-8 clean scalafmtCheckAll test scripted
+        env:
+          PROTOFETCH_GIT_PROTOCOL: https
       - name: Cleanup
         run: |
           rm -rf "$HOME/.ivy2/local" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
+        uses: olafurpg/setup-scala@v14
         with:
-          java-version: "openjdk@1.17"
+          java-version: "temurin@17"
       - run: .github/scripts/gpg-setup.sh
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Scala
         uses: olafurpg/setup-scala@v14
         with:
-          java-version: "temurin@17"
+          java-version: "openjdk@1.17"
       - run: .github/scripts/gpg-setup.sh
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -28,10 +28,10 @@ lazy val root = (project in file("."))
     sbtPlugin := true,
     addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6"),
     libraryDependencies ++= Seq(
-      "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.5.1",
-      "org.apache.commons"             % "commons-compress" % "1.21",
-      "dev.zio"                       %% "zio-test"         % "1.0.14" % Test,
-      "dev.zio"                       %% "zio-test-sbt"     % "1.0.14" % Test
+      "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.0",
+      "org.apache.commons"             % "commons-compress" % "1.24.0",
+      "dev.zio"                       %% "zio-test"         % "1.0.18" % Test,
+      "dev.zio"                       %% "zio-test-sbt"     % "1.0.18" % Test
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     scriptedLaunchOpts := {

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    scalaVersion            := "2.12.15",
+    scalaVersion            := "2.12.18",
     dynverSonatypeSnapshots := true,
     organization            := "com.coralogix",
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -38,6 +38,11 @@ lazy val root = (project in file("."))
       scriptedLaunchOpts.value ++
         Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
     },
-    scriptedBufferLog := false
+    scriptedBufferLog := false,
+    pluginCrossBuild / sbtVersion := {
+      scalaBinaryVersion.value match {
+        case "2.12" => "1.6.2"
+      }
+    }
   )
   .enablePlugins(SbtPlugin)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.6.2
+sbt.version=1.9.7
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"      % "2.4.2")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"    % "1.5.11")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"    % "1.5.12")
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"           % "2.1.1")
 addSbtPlugin("com.eed3si9n"   % "sbt-projectmatrix" % "0.9.0")

--- a/src/main/scala/com/coralogix/sbtprotodep/Protodep.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/Protodep.scala
@@ -50,7 +50,7 @@ object Protodep extends AutoPlugin {
   def generateProject(
     name: String,
     path: Option[String] = None,
-    backend: BackendType = BackendType.Protodep
+    backend: BackendType = BackendType.Protofetch
   ): Project =
     Project(name, file(path.getOrElse(name)))
       .enablePlugins(GrpcDependencies)

--- a/src/main/scala/com/coralogix/sbtprotodep/package.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/package.scala
@@ -1,6 +1,6 @@
 package com.coralogix
 
 package object sbtprotodep {
-  lazy val protofetchVersion = "v0.1.0"
+  lazy val protofetchVersion = "v0.1.1"
   lazy val protodepVersion = "v0.1.8"
 }

--- a/src/main/scala/com/coralogix/sbtprotodep/package.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/package.scala
@@ -2,5 +2,5 @@ package com.coralogix
 
 package object sbtprotodep {
   lazy val protofetchVersion = "v0.1.0"
-  lazy val protodepVersion = "v0.1.6"
+  lazy val protodepVersion = "v0.1.8"
 }

--- a/src/sbt-test/sbt-protodep/rules-grpc-api/build.sbt
+++ b/src/sbt-test/sbt-protodep/rules-grpc-api/build.sbt
@@ -3,12 +3,12 @@ logLevel := Level.Debug
 Global / protodepUseHttps := true
 enablePlugins(Protodep)
 
-ThisBuild / scalaVersion := "2.13.3"
+ThisBuild / scalaVersion := "2.13.12"
 
 lazy val protodeps = Protodep.generateProject("grpc-deps")
 
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.3",
     scalacOptions ++= Seq("-verbose")
-  ).dependsOn(protodeps)
+  )
+  .dependsOn(protodeps)

--- a/src/sbt-test/sbt-protodep/rules-grpc-api/project/build.properties
+++ b/src/sbt-test/sbt-protodep/rules-grpc-api/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.5
+sbt.version=1.9.7

--- a/src/sbt-test/sbt-protodep/rules-grpc-api/project/plugins.sbt
+++ b/src/sbt-test/sbt-protodep/rules-grpc-api/project/plugins.sbt
@@ -6,5 +6,5 @@
   else addSbtPlugin("com.coralogix" % "sbt-protodep" % pluginVersion)
 }
 
-addSbtPlugin("com.thesamet"  % "sbt-protoc" % "1.0.0-RC4")
-libraryDependencies += "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.4.2"
+addSbtPlugin("com.thesamet"  % "sbt-protoc" % "1.0.6")
+libraryDependencies += "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.0"

--- a/src/sbt-test/sbt-protodep/rules-grpc-api/protodep.toml
+++ b/src/sbt-test/sbt-protodep/rules-grpc-api/protodep.toml
@@ -2,4 +2,4 @@ proto_outdir = "./grpc-deps/target/protobuf_external_src"
 
 [[dependencies]]
 target = "github.com/coralogix/rules-api-protobuf/"
-revision = "v0.1"
+revision = "v0.9"

--- a/src/sbt-test/sbt-protodep/rules-grpc-api/src/main/scala/Main.scala
+++ b/src/sbt-test/sbt-protodep/rules-grpc-api/src/main/scala/Main.scala
@@ -1,4 +1,3 @@
-
 object Main extends App {
-  val svc: com.coralogix.rules.grpc.external.v1.RuleGroupsService.Service = null
+  val svc: com.coralogix.rules.v1.rule_groups_service.ZioRuleGroupsService.RuleGroupsService = null
 }

--- a/src/sbt-test/sbt-protodep/rules-grpc-api/test
+++ b/src/sbt-test/sbt-protodep/rules-grpc-api/test
@@ -1,9 +1,9 @@
 > clean
-$ absent grpc-deps/target/protobuf_external_src/com/coralogix/rules/v1/RuleGroupsService.proto
-$ absent grpc-deps/target/scala-2.13/src_managed/main/scalapb/com/coralogix/rules/grpc/external/v1/RuleGroupsService/ZioRulegroupsService.scala
-$ absent grpc-deps/target/scala-2.13/classes/com/coralogix/rules/grpc/external/v1/RuleGroupsService/ZioRuleGroupsService.class
+$ absent grpc-deps/target/protobuf_external_src/com/coralogix/rules/v1/rule_groups_service.proto
+$ absent grpc-deps/target/scala-2.13/src_managed/main/scalapb/com/coralogix/rules/v1/rule_groups_service/ZioRuleGroupsService.scala
+$ absent grpc-deps/target/scala-2.13/classes/com/coralogix/rules/v1/rule_groups_service/ZioRuleGroupsService.class
 > grpc-deps/forcedProtodepFetchProtoFiles
 > grpc-deps/compile
-$ exists grpc-deps/target/protobuf_external_src/com/coralogix/rules/v1/RuleGroupsService.proto
-$ exists grpc-deps/target/scala-2.13/src_managed/main/scalapb/com/coralogix/rules/grpc/external/v1/RuleGroupsService/ZioRuleGroupsService.scala
-$ exists grpc-deps/target/scala-2.13/classes/com/coralogix/rules/grpc/external/v1/RuleGroupsService/ZioRuleGroupsService.class
+$ exists grpc-deps/target/protobuf_external_src/com/coralogix/rules/v1/rule_groups_service.proto
+$ exists grpc-deps/target/scala-2.13/src_managed/main/scalapb/com/coralogix/rules/v1/rule_groups_service/ZioRuleGroupsService.scala
+$ exists grpc-deps/target/scala-2.13/classes/com/coralogix/rules/v1/rule_groups_service/ZioRuleGroupsService.class

--- a/src/test/scala/com/coralogix/sbtprotodep/backends/ProtodepBinarySpec.scala
+++ b/src/test/scala/com/coralogix/sbtprotodep/backends/ProtodepBinarySpec.scala
@@ -10,14 +10,14 @@ import com.coralogix.sbtprotodep._
 object ProtodepBinarySpec extends DefaultRunnableSpec {
   override def spec: ZSpec[TestEnvironment, Any] =
     suite("ProtodepBinary")(
-      testM("can download and unpack protodep 0.1.2")(
+      testM("can download and unpack protodep")(
         for {
           tempDir <- ZIO.effect(Files.createTempDirectory("sbtprotodep"))
           protodepBinary <- ZIO.effect(
                               BackendBinary(
                                 _root_.sbt.util.Logger.Null,
                                 "stormcat24",
-                                "v0.1.7",
+                                protodepVersion,
                                 Some(tempDir.toFile),
                                 forceDownload = true,
                                 backendType = BackendType.Protodep
@@ -27,9 +27,12 @@ object ProtodepBinarySpec extends DefaultRunnableSpec {
           pathExists <- ZIO.effect(path.exists())
           _          <- console.putStrLn(s"Downloaded protodep to $path")
           version    <- ZIO.effect(protodepBinary.version())
-        } yield assertTrue(pathExists) &&
-          assertTrue(path.toString.endsWith("/protodep")) &&
-          assertTrue(version.get == "20220211-v0.1.7")
+        } yield assertTrue(
+          pathExists,
+          path.toString.endsWith("/protodep"),
+          version.get.endsWith(protodepVersion),
+          protodepBinary.isVersion(protodepVersion)
+        )
       ),
       testM("can download protofetch")(
         for {
@@ -49,10 +52,12 @@ object ProtodepBinarySpec extends DefaultRunnableSpec {
           pathExists <- ZIO.effect(path.exists())
           _          <- console.putStrLn(s"Downloaded protofetch to $path")
           version    <- ZIO.effect(protofetchBinary.version())
-        } yield assertTrue(pathExists) &&
-          assertTrue(path.toString.endsWith("/protofetch")) &&
-          assertTrue(version.get == protofetchVersion.stripPrefix("v")) &&
-          assertTrue(protofetchBinary.isVersion(protofetchVersion))
+        } yield assertTrue(
+          pathExists,
+          path.toString.endsWith("/protofetch"),
+          version.get == protofetchVersion.stripPrefix("v"),
+          protofetchBinary.isVersion(protofetchVersion)
+        )
       )
     )
 }


### PR DESCRIPTION
* update dependencies
* fix "scripted" sbt-test setup
* improve protodep test
* make Protofetch default backend

NOTE
Version 0.6.0 of `zio-grpc-codegen` is apparently causing binary incompatibility with previous version so we should probably increment minor version in the next release.