### PR TITLE
VTX-4178 Update zio-grpc-codegen version to 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In `plugins.sbt`:
 
 ```scala
 addSbtPlugin("com.thesamet"  % "sbt-protoc" % "1.0.6")
-libraryDependencies += "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.5.1"
+libraryDependencies += "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.0"
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 addSbtPlugin("com.coralogix"  % "sbt-protodep" % "0.0.14")
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val root = (project in file("."))
     sbtPlugin := true,
     addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6"),
     libraryDependencies ++= Seq(
-      "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.5.3",
+      "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.0",
       "org.apache.commons"             % "commons-compress" % "1.24.0",
       "dev.zio"                       %% "zio-test"         % "2.0.19" % Test,
       "dev.zio"                       %% "zio-test-sbt"     % "2.0.19" % Test

--- a/src/sbt-test/sbt-protodep/rules-grpc-api/project/plugins.sbt
+++ b/src/sbt-test/sbt-protodep/rules-grpc-api/project/plugins.sbt
@@ -7,4 +7,4 @@
 }
 
 addSbtPlugin("com.thesamet"  % "sbt-protoc" % "1.0.6")
-libraryDependencies += "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.5.3"
+libraryDependencies += "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.0"


### PR DESCRIPTION
Update zio grpc codegen version to support ZIO 2.x

Need to discuss: Do we create septette branch  / major release for ZIO 2.x? 