### PR TITLE
Fail task if `protodep` returns a non-zero exit code.

### DIFF
--- a/src/main/scala/com/coralogix/sbtprotodep/GrpcDependencies.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/GrpcDependencies.scala
@@ -65,8 +65,14 @@ object GrpcDependencies extends AutoPlugin {
     val ci = insideCI.value
     val https = protodepUseHttps.value
 
-    def run(): Unit =
-      protodepBinary.fetchProtoFiles(root, ci = ci, https = https)
+    def run(): Unit = {
+      val exitCode =
+        protodepBinary.fetchProtoFiles((logLevel ?? Level.Info).value)(root, ci = ci, https = https)
+      if (exitCode != 0)
+        throw new IllegalStateException(
+          s"${protodepBinary.binary} returned non-zero exit code, aborting"
+        );
+    }
 
     val cachedProtodepUp = Tracked.inputChanged[HashModifiedFileInfo, Unit](
       s.cacheStoreFactory.make("protodep.toml")
@@ -87,6 +93,11 @@ object GrpcDependencies extends AutoPlugin {
     val protodepBinary = Protodep.autoImport.protodepBackendBinary.value
     val root = protodepRoot.value
     val https = protodepUseHttps.value
-    protodepBinary.updateProtoFiles(root, https = https)
+    val exitCode =
+      protodepBinary.updateProtoFiles((logLevel ?? Level.Info).value)(root, https = https)
+    if (exitCode != 0)
+      throw new IllegalStateException(
+        s"${protodepBinary.binary} returned non-zero exit code, aborting"
+      );
   }
 }

--- a/src/main/scala/com/coralogix/sbtprotodep/backends/BackendBinary.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/backends/BackendBinary.scala
@@ -3,7 +3,7 @@ package com.coralogix.sbtprotodep.backends
 import org.apache.commons.compress.archivers.tar.{ TarArchiveEntry, TarArchiveInputStream }
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.commons.compress.utils.IOUtils
-import sbt.util.Logger
+import sbt.util.{ Level, Logger }
 
 import java.io.{ BufferedOutputStream, File, FileOutputStream }
 import java.net.URL
@@ -15,8 +15,8 @@ import scala.language.postfixOps
 
 trait BackendBinary {
   def isVersion(desiredVersion: String): Boolean
-  def fetchProtoFiles(root: File, ci: Boolean, https: Boolean): Unit
-  def updateProtoFiles(root: File, https: Boolean): Unit
+  def fetchProtoFiles(level: Level.Value)(root: File, ci: Boolean, https: Boolean): Int
+  def updateProtoFiles(level: Level.Value)(root: File, https: Boolean): Int
   val binary: File
   private[backends] def version(): Option[String]
 }

--- a/src/main/scala/com/coralogix/sbtprotodep/backends/ProtodepBinary.scala
+++ b/src/main/scala/com/coralogix/sbtprotodep/backends/ProtodepBinary.scala
@@ -1,6 +1,6 @@
 package com.coralogix.sbtprotodep.backends
 
-import sbt.util.Logger
+import sbt.util.{ Level, Logger }
 
 import java.io.File
 import scala.language.postfixOps
@@ -26,7 +26,7 @@ class ProtodepBinary(
     }
   }
 
-  def fetchProtoFiles(root: File, ci: Boolean, https: Boolean): Unit = {
+  def fetchProtoFiles(level: Level.Value)(root: File, ci: Boolean, https: Boolean): Int = {
     val args =
       List(
         Some("--cleanup"),
@@ -35,7 +35,7 @@ class ProtodepBinary(
     Process(binary.toString :: "up" :: args, root) ! log
   }
 
-  def updateProtoFiles(root: File, https: Boolean): Unit = {
+  def updateProtoFiles(level: Level.Value)(root: File, https: Boolean): Int = {
     val args =
       List(
         Some("-f"),


### PR DESCRIPTION
[VTX-4689](https://coralogix.atlassian.net/jira/software/c/projects/VTX/boards/98?assignee=712020%3Aaba20306-56ff-4cad-9407-b23b215bfacd&assignee=61f90bf5aab3620070f540e2&assignee=626f96fa807e0000691af56c&assignee=712020%3A6875dd01-8478-48a9-b7fc-79bb350d4583&selectedIssue=VTX-4689)

If the `protodep` steps fail, we don't really want to continue to compile otherwise the errors are nonsensical and later compile steps are then dependent on the generated code which is non-existent.

I've added a pass-through environment variable for `RUST_LOG`, otherwise you can set the log level for the particular task for debugging in `sbt` directly.



[VTX-4689]: https://coralogix.atlassian.net/browse/VTX-4689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ